### PR TITLE
Tell webpack to not minimize the bundles

### DIFF
--- a/examples/basic-metrics-example/webpack.config.js
+++ b/examples/basic-metrics-example/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     // Set to false if you wish to be able to read
     // the minified code that will be generated at ./bin/index.js,
     // useful for debugging purposes.
-    minimize: true,
+    minimize: false,
   },
   target: "webworker",
   output: {

--- a/examples/basic-tracing-example/webpack.config.js
+++ b/examples/basic-tracing-example/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     // Set to false if you wish to be able to read
     // the minified code that will be generated at ./bin/index.js,
     // useful for debugging purposes.
-    minimize: true,
+    minimize: false,
   },
   target: "webworker",
   output: {

--- a/examples/otel-demo/edge/webpack.config.js
+++ b/examples/otel-demo/edge/webpack.config.js
@@ -6,7 +6,7 @@ const webpackHelpers = require("@fastly/compute-js-opentelemetry/webpack-helpers
 module.exports = {
   entry: "./src/index.js",
   optimization: {
-    minimize: true
+    minimize: false
   },
   target: "webworker",
   output: {

--- a/examples/passthrough-example/webpack.config.js
+++ b/examples/passthrough-example/webpack.config.js
@@ -10,7 +10,6 @@ module.exports = {
     // the minified code that will be generated at ./bin/index.js,
     // useful for debugging purposes.
     minimize: false,
-    // minimize: true,
   },
   target: "webworker",
   output: {

--- a/examples/readme-demo/webpack.config.js
+++ b/examples/readme-demo/webpack.config.js
@@ -10,7 +10,6 @@ module.exports = {
     // the minified code that will be generated at ./bin/index.js,
     // useful for debugging purposes.
     minimize: false,
-    // minimize: true,
   },
   target: "webworker",
   output: {


### PR DESCRIPTION
This change tells webpack to not minimize the JavaScript bundle as it makes debugging harder and does not make anything smaller or faster. All the parsing is done ahead of time when we compile to the Wasm file that gets uploaded to Fastly.