### PR TITLE
Use js-compute-runtime not fastly compute build

### DIFF
--- a/examples/readme-demo/package.json
+++ b/examples/readme-demo/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "prebuild": "webpack",
-    "build": "fastly compute build",
+    "build": "js-compute-runtime bin/index.js bin/main.wasm",
     "serve": "fastly compute serve --watch",
     "deploy": "npm run build && fastly compute deploy"
   }


### PR DESCRIPTION
This change uses an incantation to `js-compute-runtime` to build the Wasm rather than `fastly compute build` to avoid an infinite loop.