### PR TITLE
Fixes backendfetch headers not getting merged

### DIFF
--- a/src/opentelemetry-instrumentation-fastly-backend-fetch/util.ts
+++ b/src/opentelemetry-instrumentation-fastly-backend-fetch/util.ts
@@ -42,3 +42,13 @@ onShutdown(() => {
 export function setPatchTarget(target: FastlyBackendFetchInstrumentation) {
   _target = target;
 }
+
+export function headersToObject(headers: HeadersInit): Record<string, string> {
+  if (headers instanceof Headers) {
+    return Object.fromEntries([...headers]);
+  } else if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  } else {
+    return headers;
+  }
+}


### PR DESCRIPTION
This PR addresses an issue in the `FastlyBackendFetchInstrumentation` where headers were not being correctly merged in fetch requests. 