### PR TITLE
constrain node-inspect-extracted to prevent breakage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@opentelemetry/sdk-trace-base": "~1.22.0",
         "@opentelemetry/sdk-trace-web": "~1.22.0",
         "@opentelemetry/semantic-conventions": "~1.22.0",
-        "node-inspect-extracted": "^3.0.1"
+        "node-inspect-extracted": "~3.0.1"
       },
       "devDependencies": {
         "@fastly/js-compute": "^3.14.0",
@@ -2924,11 +2924,12 @@
       }
     },
     "node_modules/node-inspect-extracted": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/node-inspect-extracted/-/node-inspect-extracted-3.0.1.tgz",
-      "integrity": "sha512-27z/VXEpt0Kkaib9oCaFLKJ5yMvYyeVztRXCChYg4dTclNWLL1XKA/t6oHGe6T7C01aYy6mpffSZemnytSSJfQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-inspect-extracted/-/node-inspect-extracted-3.0.2.tgz",
+      "integrity": "sha512-lOBe4RMfICoYRKZaCXLVoBt6t8wM93QLEIp2WuvPJ5yDTEzrp+LhquGp4RV283Vd5RJ+vUvBmRrGtRu2HCgWHw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/normalize-path": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@opentelemetry/sdk-trace-base": "~1.22.0",
     "@opentelemetry/sdk-trace-web": "~1.22.0",
     "@opentelemetry/semantic-conventions": "~1.22.0",
-    "node-inspect-extracted": "^3.0.1"
+    "node-inspect-extracted": "~3.0.1"
   },
   "devDependencies": {
     "@fastly/js-compute": "^3.14.0",


### PR DESCRIPTION
weval can't seem to handle something 3.1.0 did (I can't find what)